### PR TITLE
feature: usando dotenv para variáveis de ambiente

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,2 @@
+PORT=3030
+DB_URL="mariadb://root:root@localhost:3306/games"

--- a/config/connection.js
+++ b/config/connection.js
@@ -2,7 +2,7 @@ const { Sequelize } = require('sequelize');
 const Game = require('../models/Game')
 
 
-const connection = new Sequelize("mariadb://root:root@localhost:3306/games");
+const connection = new Sequelize(process.env.DB_URL);
 connection.define("Games", Game);
 connection
     .authenticate()

--- a/index.js
+++ b/index.js
@@ -1,5 +1,8 @@
 const express = require("express");
+require('dotenv').config();
+
 const app = express();
+const port = process.env.PORT || 3000;
 
 const router = require("./routes")
 
@@ -9,7 +12,7 @@ app.use(express.urlencoded({ extended: true }))
 
 app.use('/', router)
 
-app.listen(3000, () => {
-    console.log("Servidor rodando!");
+app.listen(port, () => {
+    console.log("Servidor rodando na porta " + port);
 });
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://github.com/Casmei/ApiGames#readme",
   "dependencies": {
+    "dotenv": "^16.0.1",
     "express": "^4.18.1",
     "mariadb": "^3.0.0",
     "nodemon": "^2.0.16",


### PR DESCRIPTION
Adicionei a lib motdotla/dotenv para ler as variáveis do arquivo .env na raiz do projeto.

Após adicionar e configurar o dotenv, utilizei as variáveis PORT e DB_URL, para definir, respectivamente, a porta em que será servida a aplicação e a conexão com o banco de dados.